### PR TITLE
Fix link not work in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
 					<p>改變世界從這裡開始，我們歡迎熱愛挑戰的你</p>
 				</div>
 				<div class="col-lg-5 col-md-8 offset-lg-0 offset-md-2">
-					<br><button class="site-btn sb-gradients"><a href="https://www.cakeresume.com/companies/e-e99e93">查看職缺</button></a>					
+					<br><button class="site-btn sb-gradients" onclick="location.href='https://www.cakeresume.com/companies/e-e99e93'">查看職缺</button>					
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The HTML syntax does not allow an `a` element within a `button` element.

https://www.w3.org/TR/html52/sec-forms.html#the-button-element
```
Content model:
    Phrasing content, but there must be no interactive content descendant.
```